### PR TITLE
Improve plugin responsiveness in complicated workbooks 

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,4 +1,33 @@
-# Excel COM Errors List
+## Debugging issues
+
+This plugin supports basic logging. When problems arise a log file will be written out to your `Documents/Quandl/Excel/logs` folder. In this folder you can find a trace of the errors that have occurred and can be used for helping to debug issues. 
+
+_There are rare cases when logs files cannot be generated due to security settings or potentially unhandled exceptions._
+
+## Why do things hang/crash?
+
+There are a number of common reasons in the plugin why things hang/crash. They essentially boil down to one of the following:
+
+* Threading - Doing something silly on or with a thread and/or not cleaning up properly
+* Plugin exceptions - Excel and or the COM interface is extremely bad at handling any complex exceptions from our UDFs.
+* Async - Understand that excel often is `busy` and you must wait and then retry if your command does not succeed the first time.
+
+### Threading
+
+Excel is generally single threaded but can use multiple threads for calculations. This can get really complicated if you try to send multiple commands at it from different threads. You can also run into nasty issues with the UDFs constantly triggering other UDFs to update if your not careful. This can lead to an infinite loop which hangs the app.
+
+### Async
+
+Since the main excel thread is single threaded it can only do one thing at a time. That means that if you send a command its going to try and process it to completion/error before running another one. Otherwise it will send you an error immediately. This can really get you into trouble if you are:
+
+* Trying to send excel a command from within some code triggered by another command
+* You expect Excel to respond immediately with success and don't handle errors
+
+In general you need to figure out which exceptions should be retried and which should not.
+
+## Excel COM Errors List
+
+Below is a list of common Excel COM interaction errors that may occur when the plugin is interacting with excel directly.
 
 | CODE | Integer | Name | Meaning |
 | ------------- | ------------- | ------------- | ------------- |

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,3 @@
-## Tracker Ticket
-
-* 
-
 ## Description
 
 * 

--- a/Quandl.Excel.Console/SetupHelp.cs
+++ b/Quandl.Excel.Console/SetupHelp.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Win32;
+using System.IO;
 
 namespace Quandl.Excel.Console
 {
@@ -33,6 +34,7 @@ namespace Quandl.Excel.Console
                 RemoveAvailableOpenOption(option);
             }
             ClearSettings();
+            CleanLogs();
         }
 
         private static void SetAddinPath(string excelVersion)
@@ -145,6 +147,13 @@ namespace Quandl.Excel.Console
             }
         }
 
+        private static void CleanLogs()
+        {
+            var documentsPath = Path.Combine(Environment.ExpandEnvironmentVariables("%userprofile%"), "Documents", "Quandl");
+            Directory.Delete(documentsPath, true);
+        }
+
+        
         private enum KeySearchResult
         {
             Exist,

--- a/Quandl.Excel.UDF.Functions/Helpers/Tools.cs
+++ b/Quandl.Excel.UDF.Functions/Helpers/Tools.cs
@@ -6,10 +6,15 @@ using Quandl.Shared;
 using System.Linq;
 using Microsoft.Office.Interop.Excel;
 
-namespace Quandl.Excel.UDF.Functions
+namespace Quandl.Excel.UDF.Functions.Helpers
 {
     public class Tools
     {
+        public static void SetCellVolatile(bool value)
+        {
+            XlCall.Excel(XlCall.xlfVolatile, value);
+        }
+
         public static bool GetBoolValue(object referenceOrString)
         {
             return GetStringValue(referenceOrString).ToLower() == "true";
@@ -62,8 +67,7 @@ namespace Quandl.Excel.UDF.Functions
         public static dynamic ReferenceToRange(ExcelReference xlref)
         {
             dynamic app = ExcelDnaUtil.Application;
-            return app.Range[XlCall.Excel(XlCall.xlfReftext, xlref,
-                true)];
+            return app.Range[XlCall.Excel(XlCall.xlfReftext, xlref, true)];
         }
 
         public static List<object> GetArrayOfValues(object referenceOrString)
@@ -91,11 +95,9 @@ namespace Quandl.Excel.UDF.Functions
                 var reference = (ExcelReference)referenceOrString;
                 if (!IsSingleCell(reference))
                 {
-                    Range currentFormulaCell = Tools.ReferenceToRange(reference);
-                    var startCell = (Range)currentFormulaCell.Cells[1, 1];
-                    var endCell = (Range)currentFormulaCell.Cells[reference.RowLast - reference.RowFirst + 1, reference.ColumnLast - reference.ColumnFirst + 1];
-                    var startDate = GetDateValue(startCell);
-                    var endDate = GetDateValue(endCell);
+                    object[,] dates = (object[,])reference.GetValue();
+                    var startDate = GetDateValue(dates[0, 0]);
+                    var endDate = GetDateValue(dates[dates.GetLength(0) - 1, dates.GetLength(1) - 1]);
                     return new List<DateTime?>() { startDate, endDate };
                 }
                 else

--- a/Quandl.Excel.UDF.Functions/Locale/English.Designer.cs
+++ b/Quandl.Excel.UDF.Functions/Locale/English.Designer.cs
@@ -178,6 +178,33 @@ namespace Quandl.Excel.UDF.Functions.Locale {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No data was returned..
+        /// </summary>
+        internal static string NoDataReturned {
+            get {
+                return ResourceManager.GetString("NoDataReturned", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The cells you are trying to update may contain data already. Do you want to continue?.
+        /// </summary>
+        internal static string OverwriteExistingDataPopupDesc {
+            get {
+                return ResourceManager.GetString("OverwriteExistingDataPopupDesc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Overwrite Data?.
+        /// </summary>
+        internal static string OverwriteExistingDataPopupTitle {
+            get {
+                return ResourceManager.GetString("OverwriteExistingDataPopupTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The formula did not fully complete..
         /// </summary>
         internal static string UdfCompleteError {
@@ -187,11 +214,20 @@ namespace Quandl.Excel.UDF.Functions.Locale {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All data retrieved successfully.
+        ///   Looks up a localized string similar to Data retrieved successfully.
         /// </summary>
-        internal static string UdfCompleteSuccess {
+        internal static string UdfDataRetrievalSuccess {
             get {
-                return ResourceManager.GetString("UdfCompleteSuccess", resourceCulture);
+                return ResourceManager.GetString("UdfDataRetrievalSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Data successfully written to worksheet..
+        /// </summary>
+        internal static string UdfDataWritingSuccess {
+            get {
+                return ResourceManager.GetString("UdfDataWritingSuccess", resourceCulture);
             }
         }
         

--- a/Quandl.Excel.UDF.Functions/Locale/English.resx
+++ b/Quandl.Excel.UDF.Functions/Locale/English.resx
@@ -156,11 +156,23 @@
   <data name="MessageBoxTitle" xml:space="preserve">
     <value>No API Key Set!</value>
   </data>
+  <data name="NoDataReturned" xml:space="preserve">
+    <value>No data was returned.</value>
+  </data>
+  <data name="OverwriteExistingDataPopupDesc" xml:space="preserve">
+    <value>The cells you are trying to update may contain data already. Do you want to continue?</value>
+  </data>
+  <data name="OverwriteExistingDataPopupTitle" xml:space="preserve">
+    <value>Overwrite Data?</value>
+  </data>
   <data name="UdfCompleteError" xml:space="preserve">
     <value>The formula did not fully complete.</value>
   </data>
-  <data name="UdfCompleteSuccess" xml:space="preserve">
-    <value>All data retrieved successfully</value>
+  <data name="UdfDataRetrievalSuccess" xml:space="preserve">
+    <value>Data retrieved successfully</value>
+  </data>
+  <data name="UdfDataWritingSuccess" xml:space="preserve">
+    <value>Data successfully written to worksheet.</value>
   </data>
   <data name="UdfRequiresAPIKey" xml:space="preserve">
     <value>Please enter your api key to begin pulling data.</value>

--- a/Quandl.Excel.UDF.Functions/Quandl.Excel.UDF.Functions.csproj
+++ b/Quandl.Excel.UDF.Functions/Quandl.Excel.UDF.Functions.csproj
@@ -42,8 +42,8 @@
       <HintPath>..\packages\ExcelDna.Integration.0.33.9\lib\ExcelDna.Integration.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ExcelDna.IntelliSense, Version=0.1.8.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExcelDna.IntelliSense.0.1.8-beta8\lib\net40\ExcelDna.IntelliSense.dll</HintPath>
+    <Reference Include="ExcelDna.IntelliSense, Version=1.0.0.1547, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExcelDna.IntelliSense.1.0.0\lib\net40\ExcelDna.IntelliSense.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ExcelDna.Registration, Version=0.33.5730.42200, Culture=neutral, processorArchitecture=MSIL">
@@ -58,15 +58,18 @@
       <HintPath>..\packages\Microsoft.Office.Interop.Excel.15.0.4795.1000\lib\net20\Microsoft.Office.Interop.Excel.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="MoreLinq, Version=2.0.19309.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Quandl.Shared.Modules\bin\Debug\MoreLinq.dll</HintPath>
+    <Reference Include="MoreLinq, Version=2.0.20029.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
+      <HintPath>..\packages\morelinq.2.0.0\lib\net35\MoreLinq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
     <Reference Include="UIAComWrapper, Version=1.1.0.14, Culture=neutral, PublicKeyToken=78cbcf77433a85e5, processorArchitecture=MSIL">
       <HintPath>..\packages\UIAComWrapper.1.1.0.14\lib\net40\UIAComWrapper.dll</HintPath>
       <Private>True</Private>
@@ -75,7 +78,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AddIn.cs" />
-    <Compile Include="Common.cs" />
+    <Compile Include="Helpers\Common.cs" />
+    <Compile Include="Helpers\SheetHelper.cs" />
     <Compile Include="Locale\English.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -94,7 +98,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
-    <Compile Include="Tools.cs" />
+    <Compile Include="Helpers\Tools.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Quandl.Excel.UDF.Functions/packages.config
+++ b/Quandl.Excel.UDF.Functions/packages.config
@@ -3,8 +3,9 @@
   <package id="Excel-DNA" version="0.33.9" targetFramework="net452" />
   <package id="ExcelDna.AddIn" version="0.33.9" targetFramework="net452" />
   <package id="ExcelDna.Integration" version="0.33.9" targetFramework="net452" />
-  <package id="ExcelDna.IntelliSense" version="0.1.8-beta8" targetFramework="net461" />
+  <package id="ExcelDna.IntelliSense" version="1.0.0" targetFramework="net461" />
   <package id="ExcelDna.Registration" version="0.33.9" targetFramework="net452" />
   <package id="Microsoft.Office.Interop.Excel" version="15.0.4795.1000" targetFramework="net461" />
+  <package id="morelinq" version="2.0.0" targetFramework="net461" />
   <package id="UIAComWrapper" version="1.1.0.14" targetFramework="net461" />
 </packages>

--- a/Quandl.Shared.Modules/Excel/Exception.cs
+++ b/Quandl.Shared.Modules/Excel/Exception.cs
@@ -1,0 +1,11 @@
+﻿namespace Quandl.Shared.Excel
+{
+    public class Exception
+    {
+        public const int VBA_E_IGNORE = -2146777998;
+        public const int RPC_E_SERVERCALL_RETRYLATER = -2147417846;
+        public const int BAD_REFERENCE = -2146827864;
+        public const int UNSPECIFIED_1 = -2146827284;
+        public const int DISP_E_TYPEMISMATCH = -2147352571;
+    }
+}

--- a/Quandl.Shared.Modules/Excel/FunctionGrimReaper.cs
+++ b/Quandl.Shared.Modules/Excel/FunctionGrimReaper.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Office.Interop.Excel;
+using Quandl.Shared.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -108,10 +109,10 @@ namespace Quandl.Shared.Excel
                 // Add a message to indicate the formula's have stopped.
                 StatusBar.AddMessage(Locale.English.DownloadStopped);
             }
-            catch(Exception e)
+            catch(System.Exception e)
             {
                 StatusBar.AddException(e);
-                Utilities.LogToSentry(e);
+                Logger.log(e);
                 return false;
             }
             finally

--- a/Quandl.Shared.Modules/Excel/IStatusBar.cs
+++ b/Quandl.Shared.Modules/Excel/IStatusBar.cs
@@ -1,11 +1,9 @@
-﻿using System;
-
-namespace Quandl.Shared.Excel
+﻿namespace Quandl.Shared.Excel
 {
     public interface IStatusBar
     {
         void AddMessage(string message);
 
-        void AddException(Exception e);
+        void AddException(System.Exception e);
     }
 }

--- a/Quandl.Shared.Modules/Excel/NullStatusBar.cs
+++ b/Quandl.Shared.Modules/Excel/NullStatusBar.cs
@@ -12,7 +12,7 @@ namespace Quandl.Shared.Excel
         {
         }
 
-        public void AddException(Exception e)
+        public void AddException(System.Exception e)
         {
         }
     }

--- a/Quandl.Shared.Modules/Helpers/CheckedItemHelper.cs
+++ b/Quandl.Shared.Modules/Helpers/CheckedItemHelper.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Windows;
 using Quandl.Shared.Models;
 
-namespace Quandl.Excel.Addin.UI.Helpers
+namespace Quandl.Shared.Helpers
 {
     // http://stackoverflow.com/questions/2251260/how-to-develop-treeview-with-checkboxes-in-wpf
     public class CheckedItemHelper : DependencyObject

--- a/Quandl.Shared.Modules/Helpers/Logger.cs
+++ b/Quandl.Shared.Modules/Helpers/Logger.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.IO;
+using SharpRaven;
+using SharpRaven.Data;
+using System.Diagnostics;
+using System.Collections.Generic;
+using Quandl.Shared.Properties;
+using MoreLinq;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Quandl.Shared.Helpers
+{
+    public class Logger
+    {
+        public enum LogType {FULL, STATUS, NOSENTRY};
+
+        public const string LogPath = @"Quandl\Excel\logs";
+
+        private const bool ENABLE_SENTRY_LOG = true;
+        private const bool ENABLE_DISK_LOG = true;
+
+        private const string FullLogPrefix = "quandl";
+        private const string StatusLogPrefix = "status";
+
+        public static void log(string message, Dictionary<string, string> additionalData = null, LogType t = LogType.FULL)
+        {
+            log(new Exception(message), additionalData, t);
+        }
+
+        public static void log(Exception e, Dictionary<string, string> additionalData = null, LogType t = LogType.FULL)
+        {
+            Trace.WriteLine(e.Message);
+            Trace.WriteLine(e.StackTrace);
+
+            // Add the stack trace into the additional data if one is available
+            if (additionalData == null)
+            {
+                additionalData = new Dictionary<string, string>() { };
+            }
+            if(e.StackTrace != null && e.StackTrace.Length > 0) {
+                additionalData["StackTrace"] = e.StackTrace;
+            }
+
+            // Write to sentry logging if applicable
+            if (ENABLE_SENTRY_LOG && t != LogType.NOSENTRY)
+            {
+                LogToSentry(e, additionalData);
+            }
+
+            // Write to disk logging if applicable
+            if (ENABLE_DISK_LOG)
+            {
+                LogToDisk(e, additionalData, t);
+            }
+        }
+
+        // Attempt to write to sentry but if it does not work then continue on.
+        private static async void LogToSentry(Exception exception, Dictionary<string, string> additionalData)
+        {
+            try
+            {
+                SetSentryData(exception, "Excel-Version", Utilities.ExcelVersionNumber);
+                SetSentryData(exception, "Addin-Release-Version", Utilities.ReleaseVersion);
+                SetSentryData(exception, "X-API-Token", QuandlConfig.ApiKey);
+                if (additionalData != null)
+                {
+                    additionalData.ForEach(k => SetSentryData(exception, k.Key, k.Value));
+                }
+                var ravenClient = new RavenClient(Settings.Default.SentryUrl);
+                await ravenClient.CaptureAsync(new SentryEvent(exception));
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.Message);
+                Trace.WriteLine(e.StackTrace);
+            }
+        }
+
+        private static void SetSentryData(Exception exception, string key, string value)
+        {
+            if (key != null && !exception.Data.Contains(key))
+                exception.Data.Add(key, value);
+        }
+
+        // Attempt to write to disk but if it does not work then continue on.
+        private static async void LogToDisk(Exception exception, Dictionary<string, string> additionalData, LogType t = LogType.FULL)
+        {
+            try
+            {
+                var prefix = FullLogPrefix;
+                if (t == LogType.STATUS)
+                {
+                    prefix = StatusLogPrefix;
+                }
+
+                Directory.CreateDirectory(LogPath);
+                using (StreamWriter w = File.AppendText($"{LogPath}/{prefix}-{DateTime.UtcNow.ToString("yyyy-MM-ddTHH-00-00Z")}.txt"))
+                {
+                    var now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH-mm-ssZ");
+                    await w.WriteLineAsync($"{now} : {exception.Message}");
+                    var tasks = additionalData.ToList().Select((key, val) =>
+                       w.WriteLineAsync($"{now} : {key} {val}")
+                    );
+                    await Task.WhenAll(tasks);
+                }
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine(e.Message);
+                Trace.WriteLine(e.StackTrace);
+            }
+        }
+    }
+}

--- a/Quandl.Shared.Modules/Locale/English.Designer.cs
+++ b/Quandl.Shared.Modules/Locale/English.Designer.cs
@@ -86,23 +86,5 @@ namespace Quandl.Shared.Locale {
                 return ResourceManager.GetString("DownloadStopping", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The cells you are trying to update may contain data already. Do you want to continue?.
-        /// </summary>
-        internal static string OverwriteExistingDataPopupDesc {
-            get {
-                return ResourceManager.GetString("OverwriteExistingDataPopupDesc", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Overwrite Data?.
-        /// </summary>
-        internal static string OverwriteExistingDataPopupTitle {
-            get {
-                return ResourceManager.GetString("OverwriteExistingDataPopupTitle", resourceCulture);
-            }
-        }
     }
 }

--- a/Quandl.Shared.Modules/Locale/English.resx
+++ b/Quandl.Shared.Modules/Locale/English.resx
@@ -126,10 +126,4 @@
   <data name="DownloadStopping" xml:space="preserve">
     <value>Stopping all Quandl data downloads.</value>
   </data>
-  <data name="OverwriteExistingDataPopupDesc" xml:space="preserve">
-    <value>The cells you are trying to update may contain data already. Do you want to continue?</value>
-  </data>
-  <data name="OverwriteExistingDataPopupTitle" xml:space="preserve">
-    <value>Overwrite Data?</value>
-  </data>
 </root>

--- a/Quandl.Shared.Modules/Quandl.Shared.Modules.csproj
+++ b/Quandl.Shared.Modules/Quandl.Shared.Modules.csproj
@@ -46,8 +46,8 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio 14.0\Visual Studio Tools for Office\PIA\Office15\Microsoft.Office.Interop.Excel.dll</HintPath>
     </Reference>
-    <Reference Include="MoreLinq, Version=2.0.19309.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
-      <HintPath>..\packages\morelinq.2.0.0-beta04\lib\net35\MoreLinq.dll</HintPath>
+    <Reference Include="MoreLinq, Version=2.0.20029.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
+      <HintPath>..\packages\morelinq.2.0.0\lib\net35\MoreLinq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -86,14 +86,15 @@
   <ItemGroup>
     <Compile Include="Errors\MissingFormulaException.cs" />
     <Compile Include="Errors\QuandlErrorBase.cs" />
+    <Compile Include="Excel\Exception.cs" />
     <Compile Include="Excel\FunctionGrimReaper.cs" />
     <Compile Include="Excel\IStatusBar.cs" />
     <Compile Include="Excel\NullStatusBar.cs" />
-    <Compile Include="Excel\SheetHelper.cs" />
     <Compile Include="Excel\StatusBar.cs" />
     <Compile Include="Excel\ThreadedStatusBar.cs" />
     <Compile Include="FunctionUpdater.cs" />
     <Compile Include="Helpers\CheckedItemHelper.cs" />
+    <Compile Include="Helpers\Logger.cs" />
     <Compile Include="Helpers\Updater.cs" />
     <Compile Include="Locale\English.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/Quandl.Shared.Modules/Utilities.cs
+++ b/Quandl.Shared.Modules/Utilities.cs
@@ -1,14 +1,8 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using Microsoft.Office.Interop.Excel;
-using Quandl.Shared.Properties;
-using SharpRaven;
-using SharpRaven.Data;
-using System.Diagnostics;
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using MoreLinq;
 using System.Drawing;
 
 namespace Quandl.Shared
@@ -27,33 +21,9 @@ namespace Quandl.Shared
             Customer
         };
 
-        private const bool ENABLE_SENTRY_LOG = true;
         private const int WinDefaultDpi = 96;
 
         public static string ExcelVersionNumber { get; set; }
-
-        public static async void LogToSentry(System.Exception exception, Dictionary<string, string> additionalData = null)
-        {
-            Trace.WriteLine(exception.Message);
-
-            if (ENABLE_SENTRY_LOG)
-            {
-                SetSentryData(exception, "Excel-Version", Utilities.ExcelVersionNumber);
-                SetSentryData(exception, "Addin-Release-Version", Utilities.ReleaseVersion);
-                SetSentryData(exception, "X-API-Token", QuandlConfig.ApiKey);
-                if (additionalData != null)
-                {
-                    additionalData.ForEach(k => SetSentryData(exception, k.Key, k.Value));
-                }
-                var ravenClient = new RavenClient(Settings.Default.SentryUrl);
-                await ravenClient.CaptureAsync(new SentryEvent(exception));
-            }
-        }
-
-        public static void LogToSentry(Exception exception)
-        {
-            LogToSentry(exception, null);
-        }
 
         public static ArrayList GetMatchedListByOrder(ArrayList columnNames, ArrayList columnNamesList,
             ArrayList dataList)
@@ -201,12 +171,6 @@ namespace Quandl.Shared
             result.Add(item);
             result.AddRange(list);
             return result;
-        }
-
-        private static void SetSentryData(Exception exception, string key, string value)
-        {
-            if (key != null && !exception.Data.Contains(key))
-                exception.Data.Add(key, value);
         }
     }
 }

--- a/Quandl.Shared.Modules/Web.cs
+++ b/Quandl.Shared.Modules/Web.cs
@@ -14,6 +14,7 @@ using Quandl.Shared.Models;
 using Quandl.Shared.Models.Browse;
 using Quandl.Shared.Properties;
 using System.Windows;
+using Quandl.Shared.Helpers;
 
 namespace Quandl.Shared
 {
@@ -224,7 +225,7 @@ namespace Quandl.Shared
                 var data2 = await resp.Content.ReadAsStringAsync();
                 var errorData =  JsonConvert.DeserializeObject<QuandlError>(data2, JsonSettings());
                 var error = new QuandlErrorBase(resp.StatusCode, errorData.Code, errorData.Message);
-                Utilities.LogToSentry(error, 
+                Logger.log(error, 
                     new Dictionary<string, string>(){ { "APIKey", QuandlConfig.ApiKey }, {  "RequestUrl", relativeUrl } }
                 );
                 MessageBox.Show(Locale.English.ApiExperiencingIssues);

--- a/Quandl.Shared.Modules/models/DataColumn.cs
+++ b/Quandl.Shared.Modules/models/DataColumn.cs
@@ -1,5 +1,5 @@
 ﻿using System.Windows;
-using Quandl.Excel.Addin.UI.Helpers;
+using Quandl.Shared.Helpers;
 
 namespace Quandl.Shared.Models
 {

--- a/Quandl.Shared.Modules/packages.config
+++ b/Quandl.Shared.Modules/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="LinqJoin" version="1.0.1" targetFramework="net461" />
-  <package id="morelinq" version="2.0.0-beta04" targetFramework="net461" />
+  <package id="morelinq" version="2.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
   <package id="Octokit" version="0.23.0" targetFramework="net461" />
   <package id="SharpRaven" version="2.1.0" targetFramework="net461" />

--- a/Quandl.Test.UnitTests/Quandl.Test.UnitTests/Quandl.Test.UnitTests.csproj
+++ b/Quandl.Test.UnitTests/Quandl.Test.UnitTests/Quandl.Test.UnitTests.csproj
@@ -40,16 +40,16 @@
       <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.5.21.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.5.29.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.5.29\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Quandl.Test.UnitTests/Quandl.Test.UnitTests/packages.config
+++ b/Quandl.Test.UnitTests/Quandl.Test.UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
-  <package id="Moq" version="4.5.21" targetFramework="net452" />
+  <package id="Moq" version="4.5.29" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
-  <package id="NUnit" version="3.4.1" targetFramework="net452" />
+  <package id="NUnit" version="3.5.0" targetFramework="net461" />
 </packages>

--- a/QuandlExcelAddinWindows/Quandl.Excel.Addin.csproj
+++ b/QuandlExcelAddinWindows/Quandl.Excel.Addin.csproj
@@ -161,8 +161,8 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="PropertyChanged, Version=1.51.3.0, Culture=neutral, PublicKeyToken=ee3ee20bcf148ddd, processorArchitecture=MSIL">
-      <HintPath>..\packages\PropertyChanged.Fody.1.51.3\lib\dotnet\PropertyChanged.dll</HintPath>
+    <Reference Include="PropertyChanged, Version=1.52.1.0, Culture=neutral, PublicKeyToken=ee3ee20bcf148ddd, processorArchitecture=MSIL">
+      <HintPath>..\packages\PropertyChanged.Fody.1.52.1\Lib\netstandard10\PropertyChanged.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -176,8 +176,28 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="WindowsBase" />
     <Reference Include="WindowsFormsIntegration" />
-    <Reference Include="Xceed.Wpf.Toolkit, Version=2.9.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.2.9\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
+    <Reference Include="Xceed.Wpf.AvalonDock, Version=3.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.0\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=3.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=3.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=3.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xceed.Wpf.DataGrid, Version=3.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.0\lib\net40\Xceed.Wpf.DataGrid.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xceed.Wpf.Toolkit, Version=3.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.3.0\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/QuandlExcelAddinWindows/ThisAddIn.cs
+++ b/QuandlExcelAddinWindows/ThisAddIn.cs
@@ -37,7 +37,7 @@ namespace Quandl.Excel.Addin
             return CustomTaskPanes.Add(userControl, name);
         }
 
-        public void UpdateStatusBar(Exception error)
+        public void UpdateStatusBar(System.Exception error)
         {
             (new Shared.Excel.StatusBar()).AddException(error);
         }

--- a/QuandlExcelAddinWindows/Toolbar.Designer.cs
+++ b/QuandlExcelAddinWindows/Toolbar.Designer.cs
@@ -39,15 +39,15 @@ namespace Quandl.Excel.Addin
         {
             this.QuandlTab = this.Factory.CreateRibbonTab();
             this.DataGroup = this.Factory.CreateRibbonGroup();
-            this.group1 = this.Factory.CreateRibbonGroup();
-            this.SettingsGroup = this.Factory.CreateRibbonGroup();
             this.udf_builder = this.Factory.CreateRibbonButton();
+            this.group1 = this.Factory.CreateRibbonGroup();
             this.btnRefreshSheet = this.Factory.CreateRibbonButton();
             this.btnRefreshWorkbook = this.Factory.CreateRibbonButton();
             this.btnStopAll = this.Factory.CreateRibbonButton();
             this.btnFormulaToggleSplit = this.Factory.CreateRibbonSplitButton();
             this.btnEnableFormula = this.Factory.CreateRibbonButton();
             this.btnDisableFormula = this.Factory.CreateRibbonButton();
+            this.SettingsGroup = this.Factory.CreateRibbonGroup();
             this.openQuandlSettings = this.Factory.CreateRibbonButton();
             this.AboutButton = this.Factory.CreateRibbonButton();
             this.btnCheckUpdate = this.Factory.CreateRibbonButton();
@@ -58,20 +58,30 @@ namespace Quandl.Excel.Addin
             this.group1.SuspendLayout();
             this.SettingsGroup.SuspendLayout();
             this.SuspendLayout();
-            //
+            // 
             // QuandlTab
-            //
+            // 
             this.QuandlTab.ControlId.ControlIdType = Microsoft.Office.Tools.Ribbon.RibbonControlIdType.Office;
             this.QuandlTab.Groups.Add(this.DataGroup);
             this.QuandlTab.Groups.Add(this.group1);
             this.QuandlTab.Groups.Add(this.SettingsGroup);
             this.QuandlTab.Label = "Quandl";
             this.QuandlTab.Name = "QuandlTab";
-            //
+            // 
             // DataGroup
-            //
+            // 
             this.DataGroup.Items.Add(this.udf_builder);
             this.DataGroup.Name = "DataGroup";
+            // 
+            // udf_builder
+            // 
+            this.udf_builder.ControlSize = Microsoft.Office.Core.RibbonControlSize.RibbonControlSizeLarge;
+            this.udf_builder.Image = global::Quandl.Excel.Addin.Properties.Resources.get_data;
+            this.udf_builder.Label = "Get Data";
+            this.udf_builder.Name = "udf_builder";
+            this.udf_builder.OfficeImageId = "ChartShowData";
+            this.udf_builder.ShowImage = true;
+            this.udf_builder.Click += new Microsoft.Office.Tools.Ribbon.RibbonControlEventHandler(this.udfBuilder_Click);
             // 
             // group1
             // 
@@ -81,25 +91,8 @@ namespace Quandl.Excel.Addin
             this.group1.Items.Add(this.btnFormulaToggleSplit);
             this.group1.Name = "group1";
             // 
-            // SettingsGroup
-            // 
-            this.SettingsGroup.Items.Add(this.openQuandlSettings);
-            this.SettingsGroup.Items.Add(this.AboutButton);
-            this.SettingsGroup.Items.Add(this.btnCheckUpdate);
-            this.SettingsGroup.Name = "SettingsGroup";
-            // 
-            // udf_builder
-            //
-            this.udf_builder.ControlSize = Microsoft.Office.Core.RibbonControlSize.RibbonControlSizeLarge;
-            this.udf_builder.Image = global::Quandl.Excel.Addin.Properties.Resources.get_data;
-            this.udf_builder.Label = "Get Data";
-            this.udf_builder.Name = "udf_builder";
-            this.udf_builder.OfficeImageId = "ChartShowData";
-            this.udf_builder.ShowImage = true;
-            this.udf_builder.Click += new Microsoft.Office.Tools.Ribbon.RibbonControlEventHandler(this.udfBuilder_Click);
-            // 
             // btnRefreshSheet
-            //
+            // 
             this.btnRefreshSheet.ControlSize = Microsoft.Office.Core.RibbonControlSize.RibbonControlSizeLarge;
             this.btnRefreshSheet.Image = global::Quandl.Excel.Addin.Properties.Resources.refresh_sheet;
             this.btnRefreshSheet.Label = "Refresh Sheet";
@@ -107,20 +100,19 @@ namespace Quandl.Excel.Addin
             this.btnRefreshSheet.OfficeImageId = "InkDeleteAllInk";
             this.btnRefreshSheet.ShowImage = true;
             this.btnRefreshSheet.Click += new Microsoft.Office.Tools.Ribbon.RibbonControlEventHandler(this.btnRefreshWorkSheet_Click);
-            //
+            // 
             // btnRefreshWorkbook
-            //
+            // 
             this.btnRefreshWorkbook.ControlSize = Microsoft.Office.Core.RibbonControlSize.RibbonControlSizeLarge;
             this.btnRefreshWorkbook.Image = global::Quandl.Excel.Addin.Properties.Resources.refresh_workbook;
             this.btnRefreshWorkbook.Label = "Refresh Workbook";
             this.btnRefreshWorkbook.Name = "btnRefreshWorkbook";
             this.btnRefreshWorkbook.OfficeImageId = "InkDeleteAllInk";
             this.btnRefreshWorkbook.ShowImage = true;
-            this.btnRefreshWorkbook.Visible = false;
             this.btnRefreshWorkbook.Click += new Microsoft.Office.Tools.Ribbon.RibbonControlEventHandler(this.btnRefreshWorkbook_Click);
-            //
+            // 
             // btnStopAll
-            //
+            // 
             this.btnStopAll.ControlSize = Microsoft.Office.Core.RibbonControlSize.RibbonControlSizeLarge;
             this.btnStopAll.Image = global::Quandl.Excel.Addin.Properties.Resources.stop;
             this.btnStopAll.Label = "Stop";
@@ -128,9 +120,9 @@ namespace Quandl.Excel.Addin
             this.btnStopAll.OfficeImageId = "InkDeleteAllInk";
             this.btnStopAll.ShowImage = true;
             this.btnStopAll.Click += new Microsoft.Office.Tools.Ribbon.RibbonControlEventHandler(this.btnStopAll_Click);
-            //
+            // 
             // btnFormulaToggleSplit
-            //
+            // 
             this.btnFormulaToggleSplit.ControlSize = Microsoft.Office.Core.RibbonControlSize.RibbonControlSizeLarge;
             this.btnFormulaToggleSplit.Image = global::Quandl.Excel.Addin.Properties.Resources.formulas_enabled;
             this.btnFormulaToggleSplit.Items.Add(this.btnEnableFormula);
@@ -138,25 +130,32 @@ namespace Quandl.Excel.Addin
             this.btnFormulaToggleSplit.Label = "Formulas";
             this.btnFormulaToggleSplit.Name = "btnFormulaToggleSplit";
             this.btnFormulaToggleSplit.OfficeImageId = "Refresh";
-            //
+            // 
             // btnEnableFormula
-            //
+            // 
             this.btnEnableFormula.Image = global::Quandl.Excel.Addin.Properties.Resources.enable;
             this.btnEnableFormula.Label = "Enable";
             this.btnEnableFormula.Name = "btnEnableFormula";
             this.btnEnableFormula.ShowImage = true;
             this.btnEnableFormula.Click += new Microsoft.Office.Tools.Ribbon.RibbonControlEventHandler(this.btnEnableFormula_Click);
-            //
+            // 
             // btnDisableFormula
-            //
+            // 
             this.btnDisableFormula.Image = global::Quandl.Excel.Addin.Properties.Resources.disable;
             this.btnDisableFormula.Label = "Disable";
             this.btnDisableFormula.Name = "btnDisableFormula";
             this.btnDisableFormula.ShowImage = true;
             this.btnDisableFormula.Click += new Microsoft.Office.Tools.Ribbon.RibbonControlEventHandler(this.btnDisableFormula_Click);
             // 
+            // SettingsGroup
+            // 
+            this.SettingsGroup.Items.Add(this.openQuandlSettings);
+            this.SettingsGroup.Items.Add(this.AboutButton);
+            this.SettingsGroup.Items.Add(this.btnCheckUpdate);
+            this.SettingsGroup.Name = "SettingsGroup";
+            // 
             // openQuandlSettings
-            //
+            // 
             this.openQuandlSettings.ControlSize = Microsoft.Office.Core.RibbonControlSize.RibbonControlSizeLarge;
             this.openQuandlSettings.Image = global::Quandl.Excel.Addin.Properties.Resources.settings;
             this.openQuandlSettings.Label = "Settings";
@@ -196,7 +195,7 @@ namespace Quandl.Excel.Addin
             this.btnViewAll.Name = "btnViewAll";
             // 
             // Toolbar
-            //
+            // 
             this.Name = "Toolbar";
             this.RibbonType = "Microsoft.Excel.Workbook";
             this.Tabs.Add(this.QuandlTab);

--- a/QuandlExcelAddinWindows/UI/About.xaml
+++ b/QuandlExcelAddinWindows/UI/About.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Quandl.Excel.Addin.UI"
              mc:Ignorable="d" 
              d:DesignHeight="480" d:DesignWidth="640">
-    <Grid  Background="#FFF2F2F2">
+    <Grid Background="#FFF2F2F2">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="100" MinWidth="100" />
             <ColumnDefinition Width="3" MinWidth="300"/>
@@ -16,7 +16,7 @@
         </Grid.RowDefinitions>
         <Image Source="/Quandl.Excel.Addin;component/Resources/Quandl_Icon_Image.png" Width="75" Height="75"
                   VerticalAlignment="Top" Margin="0,17" Stretch="UniformToFill" Grid.Column="0" Grid.Row="0"/>
-        <StackPanel Grid.Column="1" Grid.Row="0" Margin="0,10">
+        <StackPanel Grid.Column="1" Grid.Row="0" Margin="0,10" HorizontalAlignment="Right" Height="auto" VerticalAlignment="Stretch">
             <Label Content="Quandl Excel Addin"/>
             <Label>Copyright Quandl Inc.</Label>
             <Grid Margin="0,10">
@@ -45,6 +45,7 @@
                     <Hyperlink Name="Email" NavigateUri="mailto:excel@quandl.com?subject=Quandl%20Excel" RequestNavigate="Hyperlink_RequestNavigate" FontSize="12">excel@quandl.com</Hyperlink>
                 </Label>
             </Grid>
+            <Button Name="LogButton" Content="Open Logs" Click="LogButton_Click" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="0,10" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/QuandlExcelAddinWindows/UI/About.xaml.cs
+++ b/QuandlExcelAddinWindows/UI/About.xaml.cs
@@ -1,18 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Quandl.Shared.Helpers;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace Quandl.Excel.Addin.UI
 {
@@ -35,6 +26,11 @@ namespace Quandl.Excel.Addin.UI
         {
             Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri));
             e.Handled = true;
+        }
+
+        private void LogButton_Click(object sender, RoutedEventArgs e)
+        {
+            Process.Start(Directory.GetCurrentDirectory() + @"\" + Logger.LogPath);
         }
     }
 }

--- a/QuandlExcelAddinWindows/UI/Settings/Login.xaml.cs
+++ b/QuandlExcelAddinWindows/UI/Settings/Login.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using Quandl.Shared;
 using Quandl.Shared.Errors;
 using System.Windows.Media;
+using Quandl.Shared.Helpers;
 
 namespace Quandl.Excel.Addin.UI.Settings
 {
@@ -80,7 +81,7 @@ namespace Quandl.Excel.Addin.UI.Settings
                 Globals.ThisAddIn.UpdateStatusBar(exp);
                 // For debug purposes only. This should not make it to production.
 
-                Utilities.LogToSentry(exp);
+                Logger.log(exp);
             }
         }
 

--- a/QuandlExcelAddinWindows/UI/Settings/Settings.xaml.cs
+++ b/QuandlExcelAddinWindows/UI/Settings/Settings.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Interop;
 using GongSolutions.Wpf.DragDrop.Utilities;
 using Quandl.Excel.Addin.UI.Helpers;
 using Quandl.Shared;
+using Quandl.Shared.Helpers;
 
 namespace Quandl.Excel.Addin.UI.Settings
 {
@@ -85,7 +86,7 @@ namespace Quandl.Excel.Addin.UI.Settings
             catch (Exception exp)
             {
                 Globals.ThisAddIn.UpdateStatusBar(exp);
-                Utilities.LogToSentry(exp);
+                Logger.log(exp);
             }
         }
 

--- a/QuandlExcelAddinWindows/UI/UDF Builder/ColumnSelection.xaml
+++ b/QuandlExcelAddinWindows/UI/UDF Builder/ColumnSelection.xaml
@@ -6,7 +6,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dragDrop="clr-namespace:GongSolutions.Wpf.DragDrop;assembly=GongSolutions.Wpf.DragDrop"
              xmlns:models="clr-namespace:Quandl.Shared.Models;assembly=Quandl.Shared"
-             xmlns:helpers="clr-namespace:Quandl.Excel.Addin.UI.Helpers;assembly=Quandl.Shared"
+             xmlns:helpers="clr-namespace:Quandl.Shared.Helpers;assembly=Quandl.Shared"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="400"
              Padding="0,0,0,10">

--- a/QuandlExcelAddinWindows/UI/UDF Builder/ColumnSelection.xaml.cs
+++ b/QuandlExcelAddinWindows/UI/UDF Builder/ColumnSelection.xaml.cs
@@ -1,8 +1,8 @@
 ﻿using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using Quandl.Excel.Addin.UI.Helpers;
 using Quandl.Shared.Models;
+using Quandl.Shared.Helpers;
 
 namespace Quandl.Excel.Addin.UI.UDF_Builder
 {

--- a/QuandlExcelAddinWindows/UI/UDF Builder/DateConditionSelection.xaml.cs
+++ b/QuandlExcelAddinWindows/UI/UDF Builder/DateConditionSelection.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using Quandl.Excel.Addin.UI.Helpers;
 using Quandl.Excel.Addin.UI.UDF_Builder.Filters;
 using Quandl.Shared;
+using Quandl.Shared.Helpers;
 
 namespace Quandl.Excel.Addin.UI.UDF_Builder
 {
@@ -93,7 +94,7 @@ namespace Quandl.Excel.Addin.UI.UDF_Builder
                 if (!(exception is QuandlFromDateIsGreaterThanEndDateException ||
                     exception is QuandlDateCanNotBlankException))
                 {
-                    Utilities.LogToSentry(exception);
+                    Logger.log(exception);
                     throw;
                 }
             }

--- a/QuandlExcelAddinWindows/UI/UDF Builder/FormulaInserter.xaml.cs
+++ b/QuandlExcelAddinWindows/UI/UDF Builder/FormulaInserter.xaml.cs
@@ -2,6 +2,7 @@
 using Microsoft.Office.Interop.Excel;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+using Quandl.Shared.Excel;
 
 namespace Quandl.Excel.Addin.UI.UDF_Builder
 {
@@ -53,7 +54,7 @@ namespace Quandl.Excel.Addin.UI.UDF_Builder
             catch (COMException ex)
             {
                 // Ignore no cells being selected error.
-                if (ex.HResult == -2146827864)
+                if (ex.HResult == Exception.BAD_REFERENCE)
                 {
                     Trace.WriteLine(ex.Message);
                     return;

--- a/QuandlExcelAddinWindows/UI/UDF Builder/WizardGuide.xaml.cs
+++ b/QuandlExcelAddinWindows/UI/UDF Builder/WizardGuide.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Quandl.Shared;
+using Quandl.Shared.Helpers;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -26,7 +27,7 @@ namespace Quandl.Excel.Addin.UI.UDF_Builder
             // Wait for the UI thread to become idle before rendering. Not this can have disastrous performance implications if used incorrectly.
             Dispatcher.Invoke(new System.Action(() => { }), DispatcherPriority.ContextIdle, null);
 
-            // Async check that the user is logged in our not
+            // async check that the user is logged in our not
             Loaded += async delegate
             {
                 PrepareFormEvents();
@@ -38,7 +39,7 @@ namespace Quandl.Excel.Addin.UI.UDF_Builder
                 catch (Exception exp)
                 {
                     Globals.ThisAddIn.UpdateStatusBar(exp);
-                    Utilities.LogToSentry(exp);
+                    Logger.log(exp);
                 }
             };
         }
@@ -161,7 +162,7 @@ namespace Quandl.Excel.Addin.UI.UDF_Builder
             catch (Exception exp)
             {
                 Globals.ThisAddIn.UpdateStatusBar(exp);
-                Utilities.LogToSentry(exp);
+                Logger.log(exp);
             }
         }
 
@@ -254,7 +255,7 @@ namespace Quandl.Excel.Addin.UI.UDF_Builder
             catch (COMException ex)
             {
                 // Ignore no cells being selected error.
-                if (ex.HResult == -2146827864)
+                if (ex.HResult == Quandl.Shared.Excel.Exception.BAD_REFERENCE)
                 {
                     Trace.WriteLine(ex.Message);
                     return;

--- a/QuandlExcelAddinWindows/packages.config
+++ b/QuandlExcelAddinWindows/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Extended.Wpf.Toolkit" version="2.9" targetFramework="net452" />
+  <package id="Extended.Wpf.Toolkit" version="3.0" targetFramework="net461" />
   <package id="Fody" version="1.29.4" targetFramework="net452" developmentDependency="true" />
   <package id="gong-wpf-dragdrop" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.Office.Interop.Excel" version="15.0.4795.1000" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
   <package id="Octokit" version="0.23.0" targetFramework="net461" />
-  <package id="PropertyChanged.Fody" version="1.51.3" targetFramework="net452" developmentDependency="true" />
+  <package id="PropertyChanged.Fody" version="1.52.1" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -56,10 +56,9 @@ Things to note:
 
 See [Unit Testing Guide](UNIT_TEST_GUIDE.md)
 
-
 ## FAQ
 
-For a list of excel COM exceptions and what they mean please see: [Errors](./ERRORS.md)
+For a list of excel exceptions and how to debug them please see: [Errors](./ERRORS.md)
 
 ### The VSTO Add-in and or UDF excel plugin is listed but not displaying/activating
 


### PR DESCRIPTION
## Description

* Greatly improve stability of plugin for QSERIES calls by using an async call to actually write out the data that was fetched. The plugin should now gracefully handle most errors rather than crashing excel/workbook.
* Re-introduce the `refresh workbook` button
* Add a more complex logging system to help users trace issues they are having with the plugin and or their formula
* Added in better status bar messaging to hopefully give users a better indication of which UDF query is currently being processed

## Note to the reviewer

* Consolidated the error handling so its easier to read in the code.
* Try to provide more guidance as to how errors work between our plugin and excel.
* Improved the way that quandl specific formulas are refreshed. That is they are actually totally reset, this forces excel to thing they are new formulas and then regenerate them.

## Note to QA

* None

## Dependency

* None
