### PR TITLE
Issue 29 32bit detection

### DIFF
--- a/Quandl.Shared.Modules/QuandlConfig.cs
+++ b/Quandl.Shared.Modules/QuandlConfig.cs
@@ -215,9 +215,10 @@ namespace Quandl.Shared
         private static void SetRegistryKeyValue(string key, object value,
             RegistryValueKind regValueKing = RegistryValueKind.String)
         {
-            var appKeyPath = Registry.CurrentUser.CreateSubKey(RegistrySubKey);
-            appKeyPath.SetValue(key, value, regValueKing);
-            appKeyPath.Close();
+            using (var appKeyPath = Registry.CurrentUser.CreateSubKey(RegistrySubKey))
+            {
+                appKeyPath.SetValue(key, value, regValueKing);
+            }
         }
 
         private static T GetRegistry<T>(string key)

--- a/Quandl.Shared.Modules/SetupHelp.cs
+++ b/Quandl.Shared.Modules/SetupHelp.cs
@@ -57,9 +57,10 @@ namespace Quandl.Shared
         private static void SetRegistryKeyValue(string subKey, string key, object value,
             RegistryValueKind regValueKing = RegistryValueKind.String)
         {
-            var keyPath = Registry.CurrentUser.CreateSubKey(subKey);
-            keyPath.SetValue(key, value, regValueKing);
-            keyPath.Close();
+            using (var keyPath = Registry.CurrentUser.CreateSubKey(subKey))
+            {
+                keyPath.SetValue(key, value, regValueKing);
+            }
         }
 
         private static KeySearchResult CheckQuandlAddinRegistry(string subKey, string keyName)

--- a/Quandl.Test.CodedUI/UIMap.cs
+++ b/Quandl.Test.CodedUI/UIMap.cs
@@ -133,9 +133,10 @@
         public void ClearRegistryApiKey()
         {
             string RegistrySubKey = @"SOFTWARE\Quandl\Excel Add-in";
-            var appKeyPath = Registry.CurrentUser.CreateSubKey(RegistrySubKey);
-            appKeyPath.SetValue("ApiKey", "", RegistryValueKind.String);
-            appKeyPath.Close();
+            using (var appKeyPath = Registry.CurrentUser.CreateSubKey(RegistrySubKey))
+            {
+                appKeyPath.SetValue("ApiKey", "", RegistryValueKind.String);
+            }
         }
 
         public void OpenExcelAndWorksheet()


### PR DESCRIPTION
## Description
Fixed detection of 32/64 bit excel and also fixed incorrect disposal of registry key/handles
* 

## Note to the reviewer

* only the first commit is essential

## Note to QA

* test on 32bit and 64bit systems. I think the problem might be reproducible if Office 2016 64bit is installed without Outlook.

## Dependency

* None
